### PR TITLE
feat(utils): add seeding utility

### DIFF
--- a/src/rlstudio/__init__.py
+++ b/src/rlstudio/__init__.py
@@ -1,3 +1,10 @@
-"""RLStudio core package (placeholder for Milestone 1a)."""
+"""RLStudio core package exports (Milestone 1a).
 
-__all__ = []
+Public surface kept intentionally small; expands as modules stabilize.
+"""
+
+from .core.batch import Batch  # noqa: F401
+from .core.interfaces import RLModule, ReplayBuffer, Trainer  # noqa: F401
+from .utils.seeding import seed_all  # noqa: F401
+
+__all__ = ["Batch", "RLModule", "ReplayBuffer", "Trainer", "seed_all"]

--- a/src/rlstudio/data/replay_buffer.py
+++ b/src/rlstudio/data/replay_buffer.py
@@ -5,6 +5,7 @@ Design goals (initial):
 * Store transitions column-wise for extensibility later.
 * Accept either a `Batch` or individual components.
 """
+
 from __future__ import annotations
 
 from collections import deque
@@ -38,4 +39,8 @@ class ReplayBufferSimple:
         return len(self._data)
 
     def stats(self) -> dict:
-        return {"capacity": self.capacity, "size": len(self), "batch_units": sum(b.size() for b in self._data)}
+        return {
+            "capacity": self.capacity,
+            "size": len(self),
+            "batch_units": sum(b.size() for b in self._data),
+        }

--- a/src/rlstudio/utils/seeding.py
+++ b/src/rlstudio/utils/seeding.py
@@ -1,0 +1,67 @@
+"""Seeding utilities for reproducibility (Milestone 1a).
+
+Provides a single entry point `seed_all` that seeds Python, NumPy, and torch (if available)
+and returns a dictionary capturing RNG states (sufficient for checkpointing later).
+"""
+
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Any, Dict
+
+try:  # Optional torch
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - absence path
+    torch = None  # type: ignore
+
+try:  # Optional numpy
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover
+    np = None  # type: ignore
+
+
+def seed_all(seed: int, *, deterministic: bool = False) -> Dict[str, Any]:
+    """Seed all available RNG sources.
+
+    Args:
+        seed: Base integer seed.
+        deterministic: If True and torch present, enable deterministic algorithms (best-effort).
+    Returns:
+        Dict capturing seeds and raw RNG states where accessible.
+    """
+    if seed < 0:
+        raise ValueError("seed must be non-negative")
+
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+
+    np_state = None
+    if np is not None:  # pragma: no branch - simple guard
+        np.random.seed(seed)
+        try:
+            np_state = np.random.get_state()
+        except Exception:  # pragma: no cover - fallback
+            np_state = None
+
+    torch_state = None
+    if torch is not None:  # pragma: no branch
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():  # pragma: no cover - may not run in CI
+            torch.cuda.manual_seed_all(seed)
+        if deterministic:
+            try:
+                torch.use_deterministic_algorithms(True)  # type: ignore[attr-defined]
+            except Exception:  # pragma: no cover
+                pass
+        torch_state = torch.random.get_rng_state()
+
+    return {
+        "seed": seed,
+        "deterministic": deterministic,
+        "python_random_example": random.random(),  # sample to show seeded randomness
+        "np_state": np_state,
+        "torch_state_len": int(torch_state.numel()) if torch_state is not None else None,
+        "timestamp": time.time(),
+    }

--- a/tests/test_seeding.py
+++ b/tests/test_seeding.py
@@ -1,0 +1,15 @@
+from rlstudio.utils.seeding import seed_all
+
+
+def test_seed_all_returns_dict_and_deterministic_example():
+    r1 = seed_all(123)
+    r2 = seed_all(123)
+    assert r1["seed"] == 123 and r2["seed"] == 123
+    assert r1["python_random_example"] == r2["python_random_example"]
+
+
+def test_seed_all_negative_seed_error():
+    import pytest
+
+    with pytest.raises(ValueError):
+        seed_all(-5)


### PR DESCRIPTION
Adds seed_all utility (issue #9).\n\nFeatures:\n- Seeds python, numpy, torch (if installed)\n- Deterministic flag attempts torch deterministic algorithms\n- Returns state metadata for checkpoint integration later\n- Tests for determinism and negative seed validation\n\nNext candidate: environment factory or trainer skeleton.\n